### PR TITLE
Error message instead exception + use of current page uid

### DIFF
--- a/Classes/Domain/Model/FormElements/SelectableRecipientOptions.php
+++ b/Classes/Domain/Model/FormElements/SelectableRecipientOptions.php
@@ -18,6 +18,8 @@ class SelectableRecipientOptions extends \TYPO3\CMS\Form\Domain\Model\FormElemen
     {
         if ($key === 'pageUid') {
             $value = (int) $value;
+            // use uid of current page if pageUid is not set
+            if ($value === 0) $value = $GLOBALS['TSFE']->id;
             $this->setProperty('options', $this->getOptions($value));
             // automatic cache clearing with data handler, if anything in that page changes
             if ($GLOBALS['TSFE'] instanceof \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController) {

--- a/Classes/Hooks/FormElementsOnSubmitHooks.php
+++ b/Classes/Hooks/FormElementsOnSubmitHooks.php
@@ -7,8 +7,11 @@ namespace Extrameile\FormDynamicRecipient\Hooks;
 use Extrameile\FormDynamicRecipient\Domain\Model\Recipient;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Validation\Error;
 use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
+use TYPO3\CMS\Form\Service\TranslationService;
 
 class FormElementsOnSubmitHooks
 {
@@ -28,21 +31,30 @@ class FormElementsOnSubmitHooks
 
             $uid = (int) $elementValue;
 
-            if ($uid === 0 || !array_key_exists($uid, $renderable->getProperties()['options'])) {
-                throw new \Exception('Invalid value for recipient detected', 1517428129);
+            if ($uid > 0 && array_key_exists($uid, $renderable->getProperties()['options'])) {
+                $recipient = $this->getRecipient($uid);
+                
+                // should not happen, since the TCA field is evaluated to email
+                if (!\is_array($recipient) || !GeneralUtility::validEmail($recipient['recipient_email'])) {
+                    throw new \Exception('Invalid email address for recipient detected', 1517428129);
+                }
+                
+                $formRuntime->getFormState()->setFormValue($assignedVariable . '.email', $recipient['recipient_email']);
+                $formRuntime->getFormState()->setFormValue($assignedVariable . '.label', $recipient['recipient_label']);
+                // set also name as an alias for label since this is the usual name for the recipient property
+                $formRuntime->getFormState()->setFormValue($assignedVariable . '.name', $recipient['recipient_label']);
+            } elseif ($uid > 0 && !array_key_exists($uid, $renderable->getProperties()['options'])) {
+                // throw new \Exception('Invalid value for recipient detected', 1517428129);
+                $processingRule = $renderable->getRootForm()->getProcessingRule($renderable->getIdentifier());
+                $processingRule->getProcessingMessages()->addError(
+                    GeneralUtility::makeInstance(ObjectManager::class)
+                    ->get(
+                        Error::class,
+                        TranslationService::getInstance()->translate('validation.error.1517428129', null, 'EXT:form_dynamic_recipient/Resources/Private/Language/locallang.xlf'),
+                        1517428129
+                        )
+                    );
             }
-
-            $recipient = $this->getRecipient($uid);
-
-            // should not happen, since the TCA field is evaluated to email
-            if (!\is_array($recipient) || !GeneralUtility::validEmail($recipient['recipient_email'])) {
-                throw new \Exception('Invalid email address for recipient detected', 1517428129);
-            }
-
-            $formRuntime->getFormState()->setFormValue($assignedVariable . '.email', $recipient['recipient_email']);
-            $formRuntime->getFormState()->setFormValue($assignedVariable . '.label', $recipient['recipient_label']);
-            // set also name as an alias for label since this is the usual name for the recipient property
-            $formRuntime->getFormState()->setFormValue($assignedVariable . '.name', $recipient['recipient_label']);
         }
 
         return $elementValue;

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -12,6 +12,9 @@
 			<trans-unit id="tx_formdynamicrecipient_domain_model_recipient.recipient_email">
 				<source>Recipient Email</source>
 			</trans-unit>
+			<trans-unit id="validation.error.1517428129">
+				<source>Invalid value for recipient detected.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
First change:
Add an error message instead of throwing exception if invalid value was sent. This way the field can have a prepend option and be either optional or the correct error message is shown if it is required and no option was selected.

Second change:
Use uid of current page if the pageUid is not set. This way, the same form definition can easily be used on different pages with different recipients.